### PR TITLE
Fixed HTMl validator errors and warnings.

### DIFF
--- a/src/about.html
+++ b/src/about.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <!-- Standard Meta -->
   <meta charset="utf-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <!-- Site Properties -->
   <title>Buildit - The future belongs to those who Make</title>

--- a/src/asyncgrid.html
+++ b/src/asyncgrid.html
@@ -3,8 +3,8 @@
 <head>
   <!-- Standard Meta -->
   <meta charset="utf-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <!-- Site Properties -->
   <title>Buildit</title>

--- a/src/contact-details.html
+++ b/src/contact-details.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
-<head>
+<head lang="en">
   <!-- Standard Meta -->
   <meta charset="utf-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <!-- Site Properties -->
   <title>Buildit - Where to find us</title>

--- a/src/contact.html
+++ b/src/contact.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <!-- Standard Meta -->
   <meta charset="utf-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <!-- Site Properties -->
   <title>Buildit - Where to find us</title>

--- a/src/index.html
+++ b/src/index.html
@@ -3,8 +3,8 @@
   <head>
     <!-- Standard Meta -->
     <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- Site Properties -->
     <title>Buildit</title>

--- a/src/layout.html
+++ b/src/layout.html
@@ -4,7 +4,7 @@
   <!-- Standard Meta -->
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <!-- Site Properties -->
   <title>Buildit</title>

--- a/src/make.html
+++ b/src/make.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <!-- Standard Meta -->
   <meta charset="utf-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <!-- Site Properties -->
   <title>Buildit - The future belongs to those who Make</title>

--- a/src/nestedgrid.html
+++ b/src/nestedgrid.html
@@ -3,8 +3,8 @@
 <head>
   <!-- Standard Meta -->
   <meta charset="utf-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <!-- Site Properties -->
   <title>Buildit</title>

--- a/src/people.html
+++ b/src/people.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <!-- Standard Meta -->
   <meta charset="utf-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <!-- Site Properties -->
   <title>Buildit - People</title>
@@ -95,7 +95,7 @@
         <h1>We're hiring talented frontend developers platform engineers mobile engineers creative technologists people … interested?</h1>
       </div>
       <div class="eight wide column">
-        <!--- smart recruiters column 1--->
+        <!-- smart recruiters column 1 -->
         <ul data-page="1" data-more="/more/WiproDigital/buildit.digital" class="opening-jobs grid--gutter padding--none js-openings-load">
           <li class="opening-job job column wide-1of2 medium-1of2">
             <a href="https://jobs.smartrecruiters.com/WiproDigital/111546410-delivery-lead?trid=4f98c6a8-b7c4-4ffc-b4b4-58dbdc5ad942" class="link--block details">
@@ -190,7 +190,7 @@
       </div>
 
       <div class="eight wide column">
-        <!--- smart recruiters column 2--->
+        <!-- smart recruiters column 2 -->
         <ul data-page="1" data-more="/more/WiproDigital/buildit.digital" class="opening-jobs grid--gutter padding--none js-openings-load">
           <li class="opening-job job column wide-1of2 medium-1of2">
             <a href="https://jobs.smartrecruiters.com/WiproDigital/110695432-delivery-lead?trid=4f98c6a8-b7c4-4ffc-b4b4-58dbdc5ad942" class="link--block details">

--- a/src/values.html
+++ b/src/values.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <!-- Standard Meta -->
   <meta charset="utf-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <!-- Site Properties -->
   <title>Buildit - Our Values</title>


### PR DESCRIPTION
I ran our pages through the W3C validator and it picked up some _very_ minor issues. Being the OCD markup nut that I am, I couldn't resist fixing them! :-P

The issues were:

* Missing lang attribute on some pages
* Invalid `chrome=1` content on `X-UA-Compatible` meta-tag. This is a legacy thing for the Chrome frame plug-in for IE6 - 9. I think we no longer need to worry about that 2017 :-)
* Iffy HTML comment syntax on people page

I also simplified the viewport meta-tag by removing the redundant decimal point on `initial-scale`