### PR TITLE
Improve geolocation for bangalore studio

### DIFF
--- a/src/contact.pug
+++ b/src/contact.pug
@@ -16,7 +16,7 @@ block content
           .sixteen.wide.column
             h2.subheader-large-center Studio Locations
           .eight.wide.column.contact-cards.card-white
-            a.location(href='https://www.google.com/maps/place/186+City+Rd,+London+EC1V+2NT,+UK/@51.525377,-0.087646,15z/data=!4m5!3m4!1s0x48761ca650dc3ba5:0x921df6363656512e!8m2!3d51.5277262!4d-0.0904569?hl=en-US', target='_blank')
+            a.location(href='https://www.google.com/maps/place/186+City+Rd,+London+EC1V+2NT,+UK/@51.525377,-0.087646,15z/data=!4m5!3m4!1s0x48761ca650dc3ba5:0x921df6363656512e!8m2!3d51.5277262!4d-0.0904569?hl=en-US', target='_blank' rel='noopener noreferrer')
               h2 London
               p
                 | 186 City Road
@@ -29,7 +29,7 @@ block content
               svg(height='46', width='46')
                 use(xlink:href='#map')
           .eight.wide.column.contact-cards.card-black
-            a.location(href='https://goo.gl/maps/6aGyowWaMLz', target='_blank')
+            a.location(href='https://goo.gl/maps/6aGyowWaMLz', target='_blank' rel='noopener noreferrer')
               h2 New york
               p
                 | 77 Sands Street
@@ -42,7 +42,7 @@ block content
               svg(height='46', width='46')
                 use(xlink:href='#map')
           .eight.wide.column.contact-cards.card-grey
-            a.location(href='https://www.google.com/maps?ll=39.752562,-105.002314&z=16&t=m&hl=en-US&gl=GB&mapclient=embed&q=1550+Wewatta+St+Denver,+CO+80202+USA', target='_blank')
+            a.location(href='https://www.google.com/maps?ll=39.752562,-105.002314&z=16&t=m&hl=en-US&gl=GB&mapclient=embed&q=1550+Wewatta+St+Denver,+CO+80202+USA', target='_blank' rel='noopener noreferrer')
               h2 Denver
               p
                 | 1550 Wewatta Street
@@ -55,7 +55,7 @@ block content
               svg(height='46', width='46')
                 use(xlink:href='#map')
           .eight.wide.column.contact-cards.card-white
-            a.location(href='https://www.google.com/maps?ll=53.330506,-6.228374&z=16&t=m&hl=en-US&gl=GB&mapclient=embed&cid=3233598717796492272', target='_blank')
+            a.location(href='https://www.google.com/maps?ll=53.330506,-6.228374&z=16&t=m&hl=en-US&gl=GB&mapclient=embed&cid=3233598717796492272', target='_blank' rel='noopener noreferrer')
               h2 Dublin
               p
                 | Alexandra House
@@ -68,7 +68,7 @@ block content
               svg(height='46', width='46')
                 use(xlink:href='#map')
           .eight.wide.column.contact-cards.card-blue
-            a.location(href='https://www.google.co.uk/maps/place/2+Castle+Terrace,+Edinburgh+EH1+2EL/@55.9486955,-3.2083261,17z/data=!3m1!4b1!4m5!3m4!1s0x4887c79842eb1771:0xaa89ab9f8cf5e689!8m2!3d55.9486955!4d-3.2061374', target='_blank')
+            a.location(href='https://www.google.co.uk/maps/place/2+Castle+Terrace,+Edinburgh+EH1+2EL/@55.9486955,-3.2083261,17z/data=!3m1!4b1!4m5!3m4!1s0x4887c79842eb1771:0xaa89ab9f8cf5e689!8m2!3d55.9486955!4d-3.2061374', target='_blank' rel='noopener noreferrer')
               h2 Edinburgh
               p
                 | 2 Castle Terrace
@@ -81,10 +81,10 @@ block content
               svg(height='46', width='46')
                 use(xlink:href='#map')
           .eight.wide.column.contact-cards.card-black
-            a.location(href='https://www.google.com/maps/place/Hosur+Rd,+Electronic+City,+Bengaluru,+Karnataka+560100,+India/@12.850101,77.668808,16z/data=!4m5!3m4!1s0x3bae14494a8943f7:0x768d0f9874c48675!8m2!3d12.8501009!4d77.6689256?hl=en-US', target='_blank')
+            a.location(href='https://www.google.com/maps/place/Wipro+Limited/@12.838566,77.6592042,16z/data=!4m5!3m4!1s0x0:0x1d0caf77fe02554f!8m2!3d12.8384852!4d77.6571581?hl=en-US', target='_blank' rel='noopener noreferrer')
               h2 Bangalore
               p
-                | 72 Electronic City
+                | 72 Electronics City
                 br
                 |  Hosur Road
                 br


### PR DESCRIPTION
This PR:
* modifies geolocation of bangalore studio accurately to [an existing place of parent company](https://www.google.com/maps/place/Wipro+Limited/@12.838566,77.6592042,16z/data=!4m5!3m4!1s0x0:0x1d0caf77fe02554f!8m2!3d12.8384852!4d77.6571581?hl=en-US)
* adds attribute `rel` to use [best practice](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) for opening external links