### PR TITLE
Correct address of bangalore studio

### DIFF
--- a/src/contact.pug
+++ b/src/contact.pug
@@ -84,7 +84,7 @@ block content
             a.location(href='https://www.google.com/maps/place/Wipro+Limited/@12.838566,77.6592042,16z/data=!4m5!3m4!1s0x0:0x1d0caf77fe02554f!8m2!3d12.8384852!4d77.6571581?hl=en-US', target='_blank' rel='noopener noreferrer')
               h2 Bangalore
               p
-                | 72 Electronics City
+                | 72 Electronic City
                 br
                 |  Hosur Road
                 br


### PR DESCRIPTION
An earlier PR introduced an address error. This PR fixes the one word error in address of bangalore studio.