### PR TITLE
Minor template fixes

### DIFF
--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -43,6 +43,5 @@
 
   {{>organisms-list-inline-row}}
   </section>
-  {{>scripts-footer}}
 {{/content}}
 {{/extend}}

--- a/templates/homepage.hbs
+++ b/templates/homepage.hbs
@@ -6,7 +6,6 @@
   {{/title}}
   {{{contents}}}
   {{>page-anchors}}
-  {{>scripts-footer}}
 
 {{/content}}
 {{/extend}}

--- a/templates/locations.hbs
+++ b/templates/locations.hbs
@@ -1,4 +1,5 @@
-{{#extend "page"}} {{#content "main"}}
+{{#extend "page"}}
+{{#content "main"}}
 <section>
   <main class="grav-o-container">
     <h1>{{title}}</h1>
@@ -9,4 +10,5 @@
     </div>
   </main>
 </section>
-{{/content}} {{/extend}}
+{{/content}}
+{{/extend}}

--- a/templates/partials/page-header.hbs
+++ b/templates/partials/page-header.hbs
@@ -3,7 +3,7 @@
     <div class="logo-main">
       <a href="/">
         <svg role="img" class="grav-c-logo" aria-label="buildit @ wipro digital" width="329" height="33">
-          <use xlink:href="#logo-buildit-slant"></use>
+          <use xlink:href="#buildit-logotype"></use>
         </svg>
       </a>
     </div>

--- a/templates/partials/page.hbs
+++ b/templates/partials/page.hbs
@@ -16,5 +16,7 @@
 
   {{!-- Gravity's inline SVG symbol definitions --}}
   {{>gravity-svg-symbols}}
+
+  {{> scripts-footer }}
 </body>
 </html>


### PR DESCRIPTION
Spotted a glitch in the header template that made the logo disappear.

Also, figured it was worth moving the script tags into the `page.hbs` template so that they're automatically included on all pages.