### PR TITLE
Removed duplicate script includes.

### DIFF
--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -74,8 +74,6 @@
 
   {{>organisms-list-inline-row}}
   </section>
-
-  {{>scripts-footer}}
 {{/content}}
 
 {{#content "flourish-tail"}}

--- a/templates/homepage.hbs
+++ b/templates/homepage.hbs
@@ -26,9 +26,6 @@
     <p>To learn more, check out our <a href="https://medium.com/buildit/">blog</a>.</p>
   </section>
   {{>organism-list-image-links}}
-
-  {{>scripts-footer}}
-
 {{/content}}
 
 {{/extend}}


### PR DESCRIPTION
I was getting some weird behaviour in Firefox where the hamburger toggle button didn't work. It turns out the click event handler was registered twice, so it got toggled and then toggled back again on a single click. On closer inspection, this was because some pages included all the `<script>` tags twice, so our init scripts were also being run twice.

This fixes that.