### PR TITLE
Web 167 change "organisational change" blog link on about us page

### DIFF
--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -61,7 +61,7 @@
 
   We approach each project and client as unique and we never start with a preconceived outcome or solution.
   
-  _Read more about how we approach [organisational change](https://medium.com/buildit/org-change/home) on our Medium blog._
+  _Read more about how we approach [continuous improvement and systems thinking](https://medium.com/buildit/org-change/home) on our Medium blog._
 
 
   ## Our people


### PR DESCRIPTION
Copy udpated on blog link. We could maybe split it in 2 hrefs for "continuous improvement" and "systems thinking" if it the link seems a bit long now?