### PR TITLE
Fixed double build in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ script:
     else
       npm run-script build;
     fi
-  - npm run-script build
   - npm run cypress:travis
 
 before_deploy:


### PR DESCRIPTION
Just spotted a small bugs in our Travis config (probably due to a bad merge):

* The build step was occurring twice.
* Additionally, the 2nd build wasn't setting the correct site environment config, so it defaults to "locahost" which then causes the wrong `robots.txt` to be generated and deployed.

This PR fixes those issues.