### PR TITLE
Added GA script for beta, staging and production envs.

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,15 +9,18 @@
     },
     "beta": {
       "url": "https://www-beta.buildit.digital",
-      "excludeRobots": true
+      "excludeRobots": true,
+      "googleAnalyticsTrackingId": "UA-78138413-6"
     },
     "staging": {
       "url": "https://www-staging.buildit.digital",
-      "excludeRobots": true
+      "excludeRobots": true,
+      "googleAnalyticsTrackingId": "UA-78138413-6"
     },
     "production": {
       "url": "https://buildit.wiprodigital.com",
-      "excludeRobots": false
+      "excludeRobots": false,
+      "googleAnalyticsTrackingId": "UA-78138413-2"
     }
   },
   "paths": {

--- a/gulp/metalsmith.js
+++ b/gulp/metalsmith.js
@@ -84,7 +84,8 @@ function metalsmith() {
           .metadata({
             site: {
               title: config.title,
-              url: siteEnv.url
+              url: siteEnv.url,
+              googleAnalyticsTrackingId: siteEnv.googleAnalyticsTrackingId
             },
             build: {
               excludeRobots: siteEnv.excludeRobots

--- a/templates/partials/scripts-footer.hbs
+++ b/templates/partials/scripts-footer.hbs
@@ -5,8 +5,6 @@
 <script nomodule src="/scripts/bundle.js" defer></script>
 {{#if site.googleAnalyticsTrackingId}}
 <script async src="https://www.googletagmanager.com/gtag/js?id={{site.googleAnalyticsTrackingId}}"></script>
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-78138413-2"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}

--- a/templates/partials/scripts-footer.hbs
+++ b/templates/partials/scripts-footer.hbs
@@ -3,3 +3,14 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.20.4/easing/EasePack.min.js" defer></script>
 <script type="module" src="/scripts/main.js" defer></script>
 <script nomodule src="/scripts/bundle.js" defer></script>
+{{#if site.googleAnalyticsTrackingId}}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{site.googleAnalyticsTrackingId}}"></script>
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-78138413-2"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '{{site.googleAnalyticsTrackingId}}');
+</script>
+{{/if}}


### PR DESCRIPTION
This PR adds the JS calls needs for Google Analytics to work.

To prevent our GA stats from being polluted with data from local dev or testing on staging & beta envs, I have done the following:

* On local builds the GA scripts are omitted completely
* On beta and staging a newly created GA "property" is used (so we gets stats, but they are separate from the live site)
* On production is uses the existing Buildit website GA "property".