### PR TITLE
HTML validation fixes

### DIFF
--- a/gulp/metalsmith.js
+++ b/gulp/metalsmith.js
@@ -57,8 +57,15 @@ function metalsmith() {
     }
     return null;
   });
-  handlebars.registerHelper("flourishShapes", function(name) {
-    const template = flourishTemplate(flourishShapes[name]);
+  handlebars.registerHelper("flourishShapes", function(name, excludeGradient) {
+    const contextData = flourishShapes[name];
+    // If no 2nd arg is given to the helper, Handlebars passed in its options
+    // object here
+    if (typeof excludeGradient === "object") {
+      excludeGradient = false;
+    }
+    contextData.excludeGradient = excludeGradient;
+    const template = flourishTemplate(contextData);
     return new handlebars.SafeString(template);
   });
 

--- a/pages/about.md
+++ b/pages/about.md
@@ -56,6 +56,7 @@ flourish-tail:
     shapeClass: polygon-shape-4
     reveal: true
     exclude: top
+    excludeGradient: true
   - shape: hatching-pattern-2
     shapeClass: hatching-pattern-2
     reveal: true

--- a/pages/careers.md
+++ b/pages/careers.md
@@ -47,6 +47,7 @@ flourish-tail:
     shapeClass: polygon-shape-3b
     reveal: true
     exclude: top
+    excludeGradient: true
 pullquote-main: 
   quote: This requires not just being able to do what good looks like but to stand in the middle of something not good and influence the outcome incrementally day to day to make it better.
   shapes:

--- a/pages/locations.md
+++ b/pages/locations.md
@@ -33,6 +33,7 @@ flourish-tail:
     shapeClass: polygon-shape-4
     reveal: true
     exclude: top
+    excludeGradient: true
   - shape: hatching-pattern-3
     shapeClass: hatching-pattern-3
     reveal: true

--- a/templates/partials/flourish.hbs
+++ b/templates/partials/flourish.hbs
@@ -2,7 +2,7 @@
   <div class="flourish {{baseClass}}">
     {{#each shapes}}
       <div class="{{../baseClass}}__{{shapeClass}} {{#if reveal}}js-reveal-element{{/if}}" {{#if exclude}}data-exclude="{{exclude}}" {{/if}}>
-        {{ flourishShapes shape }}
+        {{ flourishShapes shape excludeGradient }}
       </div>
     {{/each}}
   </div>

--- a/templates/partials/page-header.hbs
+++ b/templates/partials/page-header.hbs
@@ -2,7 +2,7 @@
   <div>
     <div class="logo-main">
       <a href="/">
-        <svg role="img" class="grav-c-logo" aria-label="buildit @ wipro digital" width="329" height="33" alt="">
+        <svg role="img" class="grav-c-logo" aria-label="buildit @ wipro digital" width="329" height="33">
           <title>Buildit Logo</title>
           <use xlink:href="#buildit-logotype"></use>
         </svg>

--- a/templates/partials/presentation-svg.hbs
+++ b/templates/partials/presentation-svg.hbs
@@ -1,11 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="{{viewbox}}" class="{{classname}}" aria-hidden="true">
-  <linearGradient x1="0%" y1="50%" x2="100%" y2="50%" id="{{gradientId}}">
+  <linearGradient x1="0%" y1="50%" x2="100%" y2="50%" id="{{gradientId}}" gradientUnits="objectBoundingBox">
     <stop offset="5%" class="stop-1"/>
     <stop offset="95%" class="stop-2"/>
   </linearGradient>
   <path
     class="shape"
-    gradientUnits="objectBoundingBox"
     d="{{description}}">
   </path>
 </svg>

--- a/templates/partials/presentation-svg.hbs
+++ b/templates/partials/presentation-svg.hbs
@@ -1,8 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="{{viewbox}}" class="{{classname}}" aria-hidden="true">
+{{#unless excludeGradient}}
   <linearGradient x1="0%" y1="50%" x2="100%" y2="50%" id="{{gradientId}}" gradientUnits="objectBoundingBox">
     <stop offset="5%" class="stop-1"/>
     <stop offset="95%" class="stop-2"/>
   </linearGradient>
+{{/unless}}
   <path
     class="shape"
     d="{{description}}">

--- a/templates/partials/scripts-footer.hbs
+++ b/templates/partials/scripts-footer.hbs
@@ -1,7 +1,7 @@
 <script src="https://unpkg.com/scrollreveal/dist/scrollreveal.min.js" defer></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.20.4/TweenLite.min.js" defer></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.20.4/easing/EasePack.min.js" defer></script>
-<script type="module" src="/scripts/main.js" defer></script>
+<script type="module" src="/scripts/main.js"></script>
 <script nomodule src="/scripts/bundle.js" defer></script>
 {{#if site.googleAnalyticsTrackingId}}
 <script async src="https://www.googletagmanager.com/gtag/js?id={{site.googleAnalyticsTrackingId}}"></script>


### PR DESCRIPTION
Running our beta site through the W3C's validator was producing a number of errors and warnings. This PR fixes the _errors_ that originate from the website's code (some errors are due to the SVG symbols from Gravity - the ["SVG cleanup" PR](https://github.com/buildit/gravity-ui-sass/pull/91) will ensure the next Gravity release will fix those). Specifically, this PR fixes the following issues:

* Invalid `alt` on SVG
* Invalid `defer` on `<script type="module">`
* Duplicate `id`s on pages that use flourishes
* Invalid `gradientUnits` attribute on SVG `<path>` element

Note: There are still some validations _warnings_ due to unnecessary ARIA roles. These will require a change to Gravity's CSS though, so they are being left alone for now.