### PR TITLE
Mobile bugs: WEB-248/9 - tweaked flourish settings

### DIFF
--- a/src/sass/_flourish-groups.scss
+++ b/src/sass/_flourish-groups.scss
@@ -129,7 +129,7 @@
     bottom: -55%;
     opacity: 0.5;
     svg {
-      transform: rotate(174deg);
+      transform: rotate(176deg);
     }
     .shape {
       fill: url('#polygon-shape-3-gradient');


### PR DESCRIPTION
Resolved issues WEB-248 & WEB-249.

**WEB-248:** White gap at bottoms of careers page.
**WEB-249:** Jagged scrolling on careers page.

In **flourish-groups** stylesheet - changed the transform rotate from **174 degrees** to **176 degrees** (for _polygon-shape-3a_), as it stops the boundary box for the flourish from overflowing from the footer (to outside the entire page's container). 