### PR TITLE
Added robots meta tags

### DIFF
--- a/pages/404.md
+++ b/pages/404.md
@@ -2,6 +2,8 @@
 # Meta-data
 title: 404 - Page not found
 permalink: false
+metaRobots: noindex
+private: true # Excludes this from sitemap.xml
 
 # Display
 layout: error.hbs

--- a/templates/partials/head.hbs
+++ b/templates/partials/head.hbs
@@ -4,6 +4,13 @@
 <meta http-equiv="X-UA-Compatible" content="ie=edge">
 
 <meta name="description" content="{{description}}">
+{{#if build.excludeRobots}}
+<meta name="robots" content="noindex">
+{{else}}
+  {{#if metaRobots}}
+  <meta name="robots" content="{{metaRobots}}">
+  {{/if}}
+{{/if}}
 
 <meta property="og:title" content="{{#if ogTitle }}{{ogTitle}}{{else}}{{title}}{{/if}}">
 <meta property="og:description" content="{{#if ogDescription }}{{ogDescription}}{{else}}{{description}}{{/if}}">


### PR DESCRIPTION
While playing with our Google Search Console settings I was doing a little more reading on `robots.txt` and discovered that it _only_ controls whether or not a bot will _crawl_ your website. Apparently, pages forbidden by `robots.txt` _may_ still be indexed under certain conditions. See: https://support.google.com/webmasters/answer/6062608?hl=en

![image](https://user-images.githubusercontent.com/16718916/39806956-12cf5afe-5373-11e8-81bc-ba87b4663c38.png)

Currently, our website's `robots.txt` is configured to:
* Allow crawling of all URLs on the production site
* Disallow crawling of all URLs on the staging env

The intention is that staging URLs should never appear in search engine results.

However, in light of the above, it is still possible for our staging URLs to be indexed and thus appear in search results (e.g. if someone links to them). This PR fixes that by:

* Adding an optional `<meta name="robots" ...>` tag to the page headers
* Configuring its value to be: `noindex` on:
     * The error page for all environments (we never want that to be indexed)
     * All pages on environments other than production, so staging, beta and local dev.

Additionally, I noticed that our generated `sitemap.xml` included the `404.html` error page. I have now rectified that, so it gets omitted from the sitemap.