### PR TITLE
refs #WEB-257 - removed CND scripts when not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - WEB-248 & WEB-249: Flourishes no longer cause gap below footer and janky scrolling on careers page.
 
+### Removed
+- WEB-257: CDN scripts removed where not needed
+
 
 ## [4.0.1] - 2018-05-07
 ### Fixed

--- a/templates/partials/scripts-footer.hbs
+++ b/templates/partials/scripts-footer.hbs
@@ -1,6 +1,8 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/scrollReveal.js/3.4.0/scrollreveal.min.js" defer></script>
+{{#unless path }}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.20.4/TweenLite.min.js" defer></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.20.4/easing/EasePack.min.js" defer></script>
+{{/unless}}
 <script src="/scripts/bundle.min.js" defer></script>
 {{#if site.googleAnalyticsTrackingId}}
 <script async src="https://www.googletagmanager.com/gtag/js?id={{site.googleAnalyticsTrackingId}}"></script>


### PR DESCRIPTION
this improves a bit the performance of the pages where the actual bug is happening.
Should help underpin the big a bit better.