### PR TITLE
Updated humans.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated Matteo's role in humans.txt credits.
 
 
 ## [4.0.2] - 2018-05-18

--- a/pages/humans.txt
+++ b/pages/humans.txt
@@ -29,7 +29,7 @@ team:
     twitter: "@nicusX"
 
   - name: Matteo Pescarin
-    role: Metalsmithy
+    role: Londoneer
     url: http://peach.smartart.it/
     twitter: "@ilPeach"
 


### PR DESCRIPTION
Matteo's role was incorrectly listed as "Metalsmithy" in our `humans.txt`. This grave error has now been fixed.