### PR TITLE
Fixing map pins on locations page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added Warsaw office to locations
+
+### Fixed
+- Marker locations and alt texts of map previews on locations page
 
 
 ## [4.1.1] - 2018-06-21

--- a/pages/locations/bengaluru.md
+++ b/pages/locations/bengaluru.md
@@ -3,7 +3,8 @@ title: Bangalore
 address:
   line1: 72 Electronic City
   line2: Hosur Road
-city: Bengaluru
+# omit the city in this case to avoid a repetition in the address
+# city: Bengaluru
 postcode: Bengaluru 560100
 country: India
 img:

--- a/pages/locations/bengaluru.md
+++ b/pages/locations/bengaluru.md
@@ -6,8 +6,8 @@ address:
 postcode: Bangalore 560100
 country: India
 img:
-  url: https://maps.googleapis.com/maps/api/staticmap?format=jpg&key=AIzaSyAa-P3u_B9zTs_DJ_dXRK5og7r3_n7vlT0&maptype=roadmap&scale=2&size=425x300&markers=12.838464,77.656272&zoom=15
-  alt: Bengaluru static map
+  url: https://maps.googleapis.com/maps/api/staticmap?format=jpg&key=AIzaSyAa-P3u_B9zTs_DJ_dXRK5og7r3_n7vlT0&maptype=roadmap&scale=2&size=425x300&markers=12.837073620840986,77.65719560673462&zoom=15
+  alt: Map showing the location of the Bengaluru studio
 map: https://www.google.com/maps/place/Wipro+Limited/@12.838566,77.6592042,16z/data=!4m5!3m4!1s0x0:0x1d0caf77fe02554f!8m2!3d12.8384852!4d77.6571581?hl=en-US
 draft: true
 ---

--- a/pages/locations/denver.md
+++ b/pages/locations/denver.md
@@ -6,8 +6,8 @@ city: Denver
 postcode: CO 80202
 country: USA
 img: 
-  url: https://maps.googleapis.com/maps/api/staticmap?format=jpg&key=AIzaSyAa-P3u_B9zTs_DJ_dXRK5og7r3_n7vlT0&maptype=roadmap&scale=2&size=425x300&markers=39.752562,-105.002314&zoom=16
-  alt: Denver static map
+  url: https://maps.googleapis.com/maps/api/staticmap?format=jpg&key=AIzaSyAa-P3u_B9zTs_DJ_dXRK5og7r3_n7vlT0&maptype=roadmap&scale=2&size=425x300&markers=39.75239475433594,-105.00245422823357&zoom=16
+  alt: Map showing the location of the Denver studio
 map: https://www.google.com/maps?ll=39.752562,-105.002314&z=16&t=m&hl=en-US&gl=GB&mapclient=embed&q=1550+Wewatta+St+Denver,+CO+80202+USA
 draft: true
 ---

--- a/pages/locations/dublin.md
+++ b/pages/locations/dublin.md
@@ -6,8 +6,8 @@ address:
 postcode: Dublin 4
 country: Ireland
 img: 
-  url: https://maps.googleapis.com/maps/api/staticmap?format=jpg&key=AIzaSyAa-P3u_B9zTs_DJ_dXRK5og7r3_n7vlT0&maptype=roadmap&scale=2&size=425x300&markers=53.330506,-6.228374&zoom=15
-  alt: Dublin static map
+  url: https://maps.googleapis.com/maps/api/staticmap?format=jpg&key=AIzaSyAa-P3u_B9zTs_DJ_dXRK5og7r3_n7vlT0&maptype=roadmap&scale=2&size=425x300&markers=53.33044103386714,-6.228172585833819&zoom=15
+  alt: Map showing the location of the Dublin studio
 map: https://www.google.com/maps?ll=53.330506,-6.228374&z=16&t=m&hl=en-US&gl=GB&mapclient=embed&cid=3233598717796492272
 draft: true
 ---

--- a/pages/locations/edinburgh.md
+++ b/pages/locations/edinburgh.md
@@ -6,8 +6,8 @@ city: Edinburgh
 postcode: EH1 2EL
 country: UK
 img: 
-  url: https://maps.googleapis.com/maps/api/staticmap?format=jpg&key=AIzaSyAa-P3u_B9zTs_DJ_dXRK5og7r3_n7vlT0&maptype=roadmap&scale=2&size=425x300&markers=55.948706, -3.206089&zoom=17
-  alt: Edinburgh static map
-map: https://www.google.com/maps/place/32%2F2+Castle+Terrace,+Edinburgh+EH1+2EL/@55.9470942,-3.2047936,17z/data=!3m1!4b1!4m5!3m4!1s0x4887c798ffae38b3:0x13dfc73df96e94a6!8m2!3d55.9470942!4d-3.2026049
+  url: https://maps.googleapis.com/maps/api/staticmap?format=jpg&key=AIzaSyAa-P3u_B9zTs_DJ_dXRK5og7r3_n7vlT0&maptype=roadmap&scale=2&size=425x300&markers=55.9486487,-3.2061902&zoom=17
+  alt: Map showing the location of the Edinburgh studio
+map: https://www.google.com/maps/place/2+Castle+Terrace,+Edinburgh+EH1+2EL/@55.9486962,-3.2066846,19z/data=!3m1!4b1!4m5!3m4!1s0x4887c79842eb1771:0xaa89ab9f8cf5e689!8m2!3d55.9486955!4d-3.2061374
 draft: true
 ---

--- a/pages/locations/gdansk.md
+++ b/pages/locations/gdansk.md
@@ -6,8 +6,8 @@ address:
 postcode: 80-309 Gdańsk
 country: Poland
 img: 
-  url: https://maps.googleapis.com/maps/api/staticmap?format=jpg&key=AIzaSyAa-P3u_B9zTs_DJ_dXRK5og7r3_n7vlT0&maptype=roadmap&scale=2&size=425x300&markers=54.3986681%2C18.5766752&zoom=15
-  alt: Gdańsk static map
+  url: https://maps.googleapis.com/maps/api/staticmap?format=jpg&key=AIzaSyAa-P3u_B9zTs_DJ_dXRK5og7r3_n7vlT0&maptype=roadmap&scale=2&size=425x300&markers=54.39851249592157,18.57698661508039&zoom=15
+  alt: Map showing the location of the Gdańsk studio
 map: https://www.google.com/maps/place/Alchemia+Ferrum+Tower/@54.3985837,18.5747376,17z/data=!3m1!4b1!4m5!3m4!1s0x46fd752864e2eab3:0x80d3c9302c7fad51!8m2!3d54.3985837!4d18.5769263
 draft: true
 ---

--- a/pages/locations/gdansk.md
+++ b/pages/locations/gdansk.md
@@ -3,7 +3,8 @@ title: Gdańsk
 address:
   line1: ul. Grunwaldzka 409
   line2: Alchemia Ferrum 6th floor
-city: Gdańsk
+# omit the city in this case to avoid a repetition in the address
+# city: Gdańsk
 postcode: 80-309 Gdańsk
 country: Poland
 img: 

--- a/pages/locations/london.md
+++ b/pages/locations/london.md
@@ -6,8 +6,8 @@ city: London
 postcode: EC2M 2PA
 country: UK
 img: 
-  url: https://maps.googleapis.com/maps/api/staticmap?format=jpg&key=AIzaSyAa-P3u_B9zTs_DJ_dXRK5og7r3_n7vlT0&maptype=roadmap&scale=2&size=425x300&markers=51.520177, -0.084817&zoom=17
-  alt: London skline
+  url: https://maps.googleapis.com/maps/api/staticmap?format=jpg&key=AIzaSyAa-P3u_B9zTs_DJ_dXRK5og7r3_n7vlT0&maptype=roadmap&scale=2&size=425x300&markers=51.51993868691731,-0.08485094876959921&zoom=17
+  alt: Map showing the location of the London studio
 map: https://www.google.com/maps/place/2+Finsbury+Ave,+London+EC2M+2PA/@51.5201019,-0.0871868,17z/data=!3m1!4b1!4m5!3m4!1s0x48761cadd0fdb387:0xa8fcbacd368e31b6!8m2!3d51.5201019!4d-0.0849981
 draft: true
 ---

--- a/pages/locations/new-york.md
+++ b/pages/locations/new-york.md
@@ -6,8 +6,8 @@ city: Brooklyn
 postcode: NY 11201
 country: USA
 img: 
-  url: https://maps.googleapis.com/maps/api/staticmap?format=jpg&key=AIzaSyAa-P3u_B9zTs_DJ_dXRK5og7r3_n7vlT0&maptype=roadmap&scale=2&size=425x300&markers=40.700331, -73.987327&zoom=17
-  alt: New York static map
-map: https://www.google.com/maps/place/77+Sands+St,+Brooklyn,+NY+11201,+USA/@40.700331, -73.987327,17z/data=!3m1!4b1!4m5!3m4!1s0x89c25a346b0a6f41:0xe60dd10638023226!8m2!3d40.7003578!4d-73.9873581
+  url: https://maps.googleapis.com/maps/api/staticmap?format=jpg&key=AIzaSyAa-P3u_B9zTs_DJ_dXRK5og7r3_n7vlT0&maptype=roadmap&scale=2&size=425x300&markers=40.70033451610208,-73.98736217524858&zoom=17
+  alt: Map showing the location of the New York studio
+map: https://www.google.com/maps/place/77+Sands+St,+Brooklyn,+NY+11201,+USA/@40.700331,-73.987327,17z/data=!3m1!4b1!4m5!3m4!1s0x89c25a346b0a6f41:0xe60dd10638023226!8m2!3d40.7003578!4d-73.9873581
 draft: true
 ---

--- a/pages/locations/warsaw.md
+++ b/pages/locations/warsaw.md
@@ -1,0 +1,12 @@
+---
+title: Warsaw
+address:
+  line1: Aleje Jerozolimskie 123A
+postcode: 02-017 Warszawa
+country: Poland
+img: 
+  url: https://maps.googleapis.com/maps/api/staticmap?format=jpg&key=AIzaSyAa-P3u_B9zTs_DJ_dXRK5og7r3_n7vlT0&maptype=roadmap&scale=2&size=425x300&markers=52.22498157391693,20.991161204874516&zoom=15
+  alt: Gdańsk static map
+map: https://www.google.com/maps/place/Aleje+Jerozolimskie+123A,+00-001+Warszawa,+Poland/@52.2249301,20.9888819,17z/data=!3m1!4b1!4m5!3m4!1s0x471ecc912c4600c1:0xcf1c1af486cc53d1!8m2!3d52.2249301!4d20.9910706
+draft: true
+---

--- a/pages/locations/warsaw.md
+++ b/pages/locations/warsaw.md
@@ -2,6 +2,8 @@
 title: Warsaw
 address:
   line1: Aleje Jerozolimskie 123A
+# omit the city in this case to avoid a repetition in the address
+# city: Warszawa
 postcode: 02-017 Warszawa
 country: Poland
 img: 

--- a/pages/locations/warsaw.md
+++ b/pages/locations/warsaw.md
@@ -6,7 +6,7 @@ postcode: 02-017 Warszawa
 country: Poland
 img: 
   url: https://maps.googleapis.com/maps/api/staticmap?format=jpg&key=AIzaSyAa-P3u_B9zTs_DJ_dXRK5og7r3_n7vlT0&maptype=roadmap&scale=2&size=425x300&markers=52.22498157391693,20.991161204874516&zoom=15
-  alt: Gdańsk static map
+  alt: Map showing the location of the Warsaw studio
 map: https://www.google.com/maps/place/Aleje+Jerozolimskie+123A,+00-001+Warszawa,+Poland/@52.2249301,20.9888819,17z/data=!3m1!4b1!4m5!3m4!1s0x471ecc912c4600c1:0xcf1c1af486cc53d1!8m2!3d52.2249301!4d20.9910706
 draft: true
 ---


### PR DESCRIPTION
* Corrected Edinburgh address in Google Maps link (house number 2, not "32/2")
* Updated alt texts for all studios to be more descriptive
* Corrected marker coords for all static map images (they were previously using same coords as map link, however those coords are where the full map is centred, _not_ where the location pin appears!)