### PR TITLE
Corrected capitalisation of "Buildit @ Wipro Digital" text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Corrected capitalisation of "Buildit @ Wipro Digital" text
 
 
 ## [4.1.3] - 2018-09-24

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 
 {
-  "title": "buildit @ wipro digital",
-  "description": "buildit@wiprodigital",
+  "title": "Buildit @ Wipro Digital",
+  "description": "The Buildit @ Wipro Digital website",
   "envs": {
     "local-dev": {
       "url": "http://localhost:8080",

--- a/cypress/integration/homepage.js
+++ b/cypress/integration/homepage.js
@@ -6,6 +6,6 @@ describe("Homepage", () => {
   });
 
   it("should render the page title", () => {
-    cy.title().should("include", "buildit @ wipro digital");
+    cy.title().should("include", "Buildit @ Wipro Digital");
   });
 });

--- a/gulp/metalsmith.js
+++ b/gulp/metalsmith.js
@@ -109,7 +109,7 @@ function metalsmith() {
             // (See: http://ogp.me/)
             ogType: "website",
             ogImage: "builidt-default-sharing-img.png",
-            ogImageAlt: "buildit @ wipro digital"
+            ogImageAlt: "Buildit @ Wipro Digital"
           })
           .use(jobListings())
           .use(buildInfo())

--- a/templates/partials/page-footer.hbs
+++ b/templates/partials/page-footer.hbs
@@ -1,7 +1,7 @@
 <footer{{#if footerModifierClass}} class="{{footerModifierClass}}"{{/if}}>
   <p>made with ❤️ <br>
     <a href="/">
-      <svg role="img" class="grav-c-logo" aria-label="buildit @ wipro digital" width="300" height="33">
+      <svg role="img" class="grav-c-logo" aria-label="Buildit @ Wipro Digital" width="300" height="33">
         <title>Buildit Logo</title>
         <use xlink:href="#buildit-logotype"></use>
       </svg>

--- a/templates/partials/page-header.hbs
+++ b/templates/partials/page-header.hbs
@@ -6,7 +6,7 @@
     {{else}}
       <h1>
     {{/if}}
-        <svg role="img" class="grav-c-logo" aria-label="buildit @ wipro digital" width="300" height="33">
+        <svg role="img" class="grav-c-logo" aria-label="Buildit @ Wipro Digital" width="300" height="33">
           <title>buildit @ wipro digital</title>
           <use xlink:href="#buildit-logotype"></use>
         </svg>


### PR DESCRIPTION
Marketing have informed us that, when written as text, our name should be in title case: "Buildit @ Wipro Digital".

This PR corrects any instances where that was not already the case.