### PR TITLE
Bundle scrollreveal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Upgraded dev dependencies
 - Travis builds now use Node version specified in .nvmrc
 - Enabled [Greenkeeper](https://greenkeeper.io/) to automatically update depencies
+- `scrollreveal` is now included in our JS bundle, instead of being loaded via CDN
 
 ### Fixed
 - `scrollreveal` is no longer incorrectly listed as a (non-dev) dependency

--- a/src/scripts/scrollReveal/scrollRevealModule.js
+++ b/src/scripts/scrollReveal/scrollRevealModule.js
@@ -1,3 +1,4 @@
+import ScrollReveal from "scrollreveal";
 import * as utils from "../utils.js";
 
 const defaults = {

--- a/templates/partials/scripts-footer.hbs
+++ b/templates/partials/scripts-footer.hbs
@@ -1,4 +1,3 @@
-<script src="https://cdnjs.cloudflare.com/ajax/libs/scrollReveal.js/3.4.0/scrollreveal.min.js" defer></script>
 {{#unless path }}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.20.4/TweenLite.min.js" defer></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.20.4/easing/EasePack.min.js" defer></script>


### PR DESCRIPTION
Adds scrollreveal into our JS bundle instead of being loaded separately via CDN.

In terms of performance, I estimate this won't really make any difference. We save one HTTP request, but our bundle's size increases. On balance, they probably cancel each other out.

However, this is still worth doing, since it makes it easier to stay up-to-date with new versions of scrollreveal since we can just do `npm update`.