### PR TITLE
feat(analytics): switch to GTM and track smart recruiters links

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,21 +5,31 @@
   "envs": {
     "local-dev": {
       "url": "http://localhost:8080",
-      "excludeRobots": true
+      "excludeRobots": true,
+      "gtmContainerId": "GTM-WC9XF5V",
+      "gtmAuthId": "Ds-fbHSwmiqQaCMr3raWvw",
+      "gtmPreviewId": "env-7"
     },
     "local-dev-min": {
       "url": "http://localhost:8080",
-      "excludeRobots": true
+      "excludeRobots": true,
+      "gtmContainerId": "GTM-WC9XF5V",
+      "gtmAuthId": "Ds-fbHSwmiqQaCMr3raWvw",
+      "gtmPreviewId": "env-7"
     },
     "staging": {
       "url": "https://www-staging.buildit.digital",
       "excludeRobots": true,
-      "googleAnalyticsTrackingId": "UA-78138413-6"
+      "gtmContainerId": "GTM-WC9XF5V",
+      "gtmAuthId": "Ag0PVkIlh7ZE644wJQP4JA",
+      "gtmPreviewId": "env-8"
     },
     "production": {
       "url": "https://buildit.wiprodigital.com",
       "excludeRobots": false,
-      "googleAnalyticsTrackingId": "UA-78138413-2"
+      "gtmContainerId": "GTM-WC9XF5V",
+      "gtmAuthId": "HCE83Z7j2NN-BpF0vcvrvQ",
+      "gtmPreviewId": "env-2"
     }
   },
   "paths": {

--- a/gulp/metalsmith.js
+++ b/gulp/metalsmith.js
@@ -94,7 +94,9 @@ function metalsmith() {
             site: {
               title: config.title,
               url: siteEnv.url,
-              googleAnalyticsTrackingId: siteEnv.googleAnalyticsTrackingId
+              gtmContainerId: siteEnv.gtmContainerId,
+              gtmAuthId: siteEnv.gtmAuthId,
+              gtmPreviewId: siteEnv.gtmPreviewId
             },
             build: {
               excludeRobots: siteEnv.excludeRobots

--- a/templates/partials/scripts-footer.hbs
+++ b/templates/partials/scripts-footer.hbs
@@ -1,10 +1,14 @@
 <script src="/scripts/bundle.min.js" defer></script>
-{{#if site.googleAnalyticsTrackingId}}
-<script async src="https://www.googletagmanager.com/gtag/js?id={{site.googleAnalyticsTrackingId}}"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', '{{site.googleAnalyticsTrackingId}}', { 'anonymize_ip': true });
-</script>
-{{/if}}
+{{#if site.gtmContainerId}}{{#if site.gtmAuthId}}{{#if site.gtmPreviewId}}
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth={{site.gtmAuthId}}&gtm_preview={{site.gtmPreviewId}}&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','{{site.gtmContainerId}}');</script>
+<!-- End Google Tag Manager -->
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{site.gtmContainerId}}&gtm_auth={{site.gtmAuthId}}&gtm_preview={{site.gtmPreviewId}}&gtm_cookies_win=x"
+                  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+{{/if}}{{/if}}{{/if}}


### PR DESCRIPTION
google tag manager allows us to control any future analytics changes from a web based console.
tracking the smartrecruiters links allows us to measure our success as they are a primary call to
action

fix WEB-271