### PR TITLE
Rename Dallas to Plano (WEB-273)

### DIFF
--- a/pages/locations/plano.md
+++ b/pages/locations/plano.md
@@ -1,5 +1,5 @@
 ---
-title: Dallas
+title: Plano
 address:
   line1: 5445 Legacy Drive 
   line2: Suite 300
@@ -8,7 +8,7 @@ postcode: TX 75024
 country: USA
 img: 
   url: https://maps.googleapis.com/maps/api/staticmap?format=jpg&key=AIzaSyAa-P3u_B9zTs_DJ_dXRK5og7r3_n7vlT0&maptype=roadmap&scale=2&size=425x300&markers=33.0782823,-96.8104113&zoom=14
-  alt: Map showing the location of the Dallas studio
+  alt: Map showing the location of the Plano studio
 map: https://www.google.co.uk/maps/place/5445+Legacy+Dr+%23300,+Plano,+TX+75024,+USA/@33.0785339,-96.8124283,16z/data=!4m5!3m4!1s0x864c3ccc06dd4f19:0x4de03bea3977bc1!8m2!3d33.0782823!4d-96.8082226
 draft: true
 ---


### PR DESCRIPTION
Renaming the "Dallas" entry on the locations page to "Plano", as requested by Ellen.

Fixes WEB-273