### PR TITLE
fix(travis): production was using the wrong release script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ script:
   - commitlint-travis
   - npm run-script test
   - |
-    if [[ "$TRAVIS_TAG" =~ $PROD_TAG_REGEXP ]] || [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+    if [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
       npm run-script build -- --env production;
-    elif [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    elif [ "$TRAVIS_BRANCH" == "develop" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
       npm run-script build -- --env staging;
     else
       npm run-script build;


### PR DESCRIPTION
Fixes production by setting the correct release script. Was failing because the travis.yml file had
not been updated in the scripts section to account for GIT Flow's structure.

NOTE: Must be merged via a Git Flow hotfix to merge into `master` and `develop`.