### PR TITLE
fix(locations): fixes Plano studio title

### DIFF
--- a/pages/locations/plano.md
+++ b/pages/locations/plano.md
@@ -1,7 +1,7 @@
 ---
-title: Dallas
+title: Plano
 # URI slug for this location which gets appended to https://buildit.wiprodigital.com/thing/studio/[xx]/
-citySlug: dallas
+citySlug: plano
 address:
   line1: 5445 Legacy Drive 
   line2: Suite 300


### PR DESCRIPTION
Fixes a bug introduced by a bad merge. The Dallas studio entry on locations was recently renamed to Plano (to be more specific about where the studio actually is), but the title update got undone by accident. This fixes that.