### PR TITLE
fix: pin eyeglass to 2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "eslint": "^5.15.1",
     "eslint-config-prettier": "^4.1.0",
     "eslint-plugin-prettier": "^3.0.1",
-    "eyeglass": "^2.1.0",
+    "eyeglass": "2.2.1",
     "git-last-commit": "^0.3.0",
     "gsap": "^2.0.2",
     "gulp": "^4.0.0",


### PR DESCRIPTION
Closes #199 

Eyeglass 2.2.2 and up has a bug that breaks our build. We encountered the same issue on Gravity: buildit/gravity-ui-sass#197

The fix for now is therefore to peg our dependency to the last known working version.

I have raised an issue on Eyeglass (linkedin/eyeglass#227) and, once fixed, we can update to the newer version.