### PR TITLE
Feature/next/in markdown html

### DIFF
--- a/metalsmith.js
+++ b/metalsmith.js
@@ -57,7 +57,10 @@ ms.source("./pages")
   .use(pathNoIndex())
   .use(
     inPlace({
-      suppressNoFilesError: true
+      suppressNoFilesError: true,
+      engineOptions: {
+        html: true
+      }
     })
   )
   .use(

--- a/pages/stories/better-together/index.html.md
+++ b/pages/stories/better-together/index.html.md
@@ -14,16 +14,20 @@ image:
   src: https://placeimg.com/1024/576/tech
   alt: Better Together
 ---
-Welcome to our new Buildit website featuring stories by and about our technical people and teams.
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 
-> This is the markdown content.
+- Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+- Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+- Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+- Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. uptate velit esse cillum dolore eu fugiat nulla pariatur.
 
-Lorem ipsum dolor sit amet, sit eu graeci aliquam ponderum, patrioque deseruisse intellegam ei eum, latine accumsan te pro. Eum malis latine ei, error vocibus patrioque pro ei, an nam soleat constituam. Cu nemore inermis graecis his, usu nominati intellegebat cu. Ei sea commune intellegat. Pro ut albucius scriptorem, quo ei recusabo inciderint.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia.
 
-Ex ius homero referrentur. His vero discere patrioque in, epicurei phaedrum cum et. Sed dolores deserunt te. An quo luptatum moderatius. Ad viris euripidis mea. Quas graecis consequat vix in, essent nominavi mel cu.
+> Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
 
-Nec in meis omnis phaedrum, et qui stet aliquid, nam te electram splendide. Eam ut lobortis facilisis reprimique, ut illum option noluisse quo, ne latine eloquentiam accommodare nam. Nam duis possim dolorum ad, te alia menandri sit. Dicta vitae cu mea, vim et quis instructior.
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 
-Ex qui rebum admodum. Tota laoreet voluptatibus usu ei, viris nostrud vocibus cum ex. Ius cu ridens phaedrum, est ut aeque sententiae cotidieque. Ei mazim regione vix, eu vivendum probatus eum. Stet signiferumque conclusionemque usu ex, pro cu option integre.
+<blockquote><p>The quick brown fox jumps over the lazy dog.</p><cite>- Joe Bloggs</cite></blockquote>
 
-Ullum veritus vituperata quo et. Platonem voluptatibus vix no, te ius dicunt phaedrum. No sed probo propriae percipit. Ad duo appetere probatus, ei cum enim nominavi platonem, modo autem sonet te quo. Atqui pericula consulatu vix ne, mei nostrud delicata an. Id dolorum petentium his, ne noluisse vulputate per.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.


### PR DESCRIPTION
The `in-place` metalsmith plugin takes an extra parameter which it passes on to the jstransformer it's using. This allows us to tell `jstransformer-markdown-it` to allow html in the markdown, and not escape it when rendering.

This allows us to add `<blockquote>`s with `<cite>`s within them for example.

I also updated the temporary content for one of the articles to test this. It's all lorem ipsum but that's what it was already so shouldn't be a problem!