### PR TITLE
ci(travis): specified 'next' environment for builds on `next` branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ script:
       npm run-script build -- --env production;
     elif [ "$TRAVIS_BRANCH" == "develop" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
       npm run-script build -- --env staging;
+    elif [ "$TRAVIS_BRANCH" == "next" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+      npm run-script build -- --env next;
     else
       npm run-script build;
     fi


### PR DESCRIPTION
Currently builds of the `next` branch are building using the `"local-dev"` environment, instead of the `"next"` environment.

![travis-next-build-environment](https://user-images.githubusercontent.com/46753034/58635066-caea0700-82e4-11e9-8265-c0f4daa4b592.png)

This affects some of the meta tags we put in the head of the page and it also affects the google analytics environment that the site tracks against.

Please review to make sure I haven't missed any potential issues this change would make.