### PR TITLE
ci(cloudfront invalidations): fixed `next` invalidation path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ deploy:
       ~/.local/bin/aws s3 sync dist s3://${BETA_BUCKET} --delete --region=${BETA_BUCKET_REGION} --exclude "*" --include "*.css" --content-type "text/css; charset=utf-8" &&
       ~/.local/bin/aws s3 sync dist s3://${BETA_BUCKET} --delete --region=${BETA_BUCKET_REGION} --exclude "*" --include "*.js" --content-type "application/javascript; charset=utf-8" &&
       ~/.local/bin/aws s3 sync dist s3://${BETA_BUCKET} --delete --region=${BETA_BUCKET_REGION} --include "*" --exclude "*.js" --exclude "*.html" --exclude "*.css" &&
-      ~/.local/bin/aws cloudfront create-invalidation --distribution-id ${BETA_DISTRIBUTION_ID} --paths /*
+      ~/.local/bin/aws cloudfront create-invalidation --distribution-id ${BETA_DISTRIBUTION_ID} --paths "/*"
     skip_cleanup: true
     on:
       branch: next


### PR DESCRIPTION
The cloudfront invalidation path syntax is wrong for the `next` branch.