### PR TITLE
fix(images): fixed path to images for articles with local image files

### DIFF
--- a/layouts/partials/articles/list-item.njk
+++ b/layouts/partials/articles/list-item.njk
@@ -1,8 +1,13 @@
+{% if article.image and article.image.remote %}
+  {% set imageSrc %}{{ article.image.src }}{% endset %}
+{% else %}
+  {% set imageSrc %}{{ env.url }}/{{ article.image.src or config.site.ogImage }}{% endset %}
+{% endif %}
 <li property="schema:itemListElement" typeof="schema:ListItem">
   <div class="grav-c-card-basic">
     <a href="/{{ article.path }}" property="schema:url">
       {% if article.image %}
-        <img property="schema:image" src="{{ article.image.src }}" alt="{{ article.image.alt }}" />
+        <img property="schema:image" src="{{ imageSrc }}" alt="{{ article.image.alt }}" />
         <svg role="img">
           <use xlink:href="#decoration-arrow-right"></use>
         </svg>

--- a/layouts/partials/articles/main.njk
+++ b/layouts/partials/articles/main.njk
@@ -1,7 +1,7 @@
 {% if image and image.remote %}
   {% set imageSrc %}{{ image.src }}{% endset %}
 {% else %}
-  {% set imageSrc %}{{ env.url }}/images/{{ image.src or config.site.ogImage }}{% endset %}
+  {% set imageSrc %}{{ env.url }}/{{ image.src or config.site.ogImage }}{% endset %}
 {% endif %}
 <article class="grav-o-container grav-c-article" typeof="schema:Article">
   <meta property="schema:mainEntityOfPage" content="/{{ path }}">


### PR DESCRIPTION
The image paths when using an internal (local) image do not resolve correctly. This amends them so that they resolve the same for article header and article list items.

For reference the correct image path for an article image is relative, without a starting slash. e.g. `images/articles/my-article-image.png`