### PR TITLE
fix: fixes layout bug on article pages

### DIFF
--- a/layouts/partials/articles/main.njk
+++ b/layouts/partials/articles/main.njk
@@ -4,7 +4,6 @@
   {% set imageSrc %}{{ env.url }}/{{ image.src or config.site.ogImage }}{% endset %}
 {% endif %}
 <article class="grav-c-article" typeof="schema:Article">
-  <meta property="schema:mainEntityOfPage" content="/{{ path }}">
   <header class="grav-c-page-intro">
     <h1 property="schema:headline">{{ title }}</h1>
     <p>{{ description }}</p>
@@ -12,6 +11,7 @@
     <img property="schema:image" src="{{ imageSrc }}" alt="{{ image.alt or config.site.ogImageAlt }}" />
     <link rel="schema:author schema:publisher" href="https://buildit.wiprodigital.com/thing/buildit-org">
   </header>
+  <meta property="schema:mainEntityOfPage" content="/{{ path }}">
   <div class="grav-c-ostentatious-copy" property="schema:articleBody">
     {{ contents | safe }}
   </div>


### PR DESCRIPTION
The ARTICLE element had an invisible META element as its first child, with Gravity's CSS, this
causes the next element (the article's heading in this case) to have a margin top added to it.
However, in this instance it was unintentional and caused the article headings to appear slightly
lower than headings on other pages. (This was being flagged up by Gravity's debug CSS!)

This change fixes the issue by moving the META element down so that it occurs after the heading. This hasn't altered the structured meatadata in any way (I verified it in Google's structured data testing tool)