### PR TITLE
fix: solves issues when there are no open job positions

### DIFF
--- a/cypress/integration/careers.js
+++ b/cypress/integration/careers.js
@@ -18,13 +18,4 @@ describe("Careers page", () => {
   it("renders an anchor that uses the smoothScroll feature", () => {
     cy.smoothScroll(`#${anchor}`);
   });
-
-  it("renders job positions which should link to smatrecruiters website", () => {
-    cy
-      .get(".grav-c-job-list")
-      .find(".grav-c-job-card>a")
-      .first()
-      .should("have.attr", "href")
-      .and("match", /smartrecruiters/);
-  });
 });

--- a/templates/careers.hbs
+++ b/templates/careers.hbs
@@ -29,6 +29,9 @@
   {{#each jobLocations}}
     {{>organism-job-list}}
   {{/each}}
+  {{#unless jobLocations.length }}
+    <p style="margin-bottom: 2rem;">Sorry, Buildit does not have any open positions right now. As soon as something opens up, it will be posted here so please check back again soon.</p>
+  {{/unless}}
 
   <section>
     <h2 id="the-hiring-process">The hiring process</h2>


### PR DESCRIPTION
We had a Cypress test that assumed there would always be at least one job opening on the careers page, lately that's not the case so the test has been failing (and thus failing TravisCI builds too).

I couldn't find a good solution to amend the test and Cypress own docs seem to discourage tests that are conditional
(https://docs.cypress.io/guides/core-concepts/conditional-testing.html#The-problem), so I have removed that test.

I have also added some text to appear on the careers page to inform users that there are no open job postings (otherwise it's just blank).